### PR TITLE
handle error in error handling

### DIFF
--- a/OpenAPI Client/Exception/Handler/ExceptionHandler.cs
+++ b/OpenAPI Client/Exception/Handler/ExceptionHandler.cs
@@ -9,13 +9,23 @@ namespace Bol.OpenAPI.Exception.Handler
     {
         public static BasicApiException HandleBasicApiException(HttpWebResponse response)
         {
-            using (Stream stream = response.GetResponseStream())
+            string status = response.StatusCode.ToString();
+            string message = response.StatusDescription;
+            try
             {
-                StreamReader reader = new StreamReader(stream, Encoding.UTF8);
-                string responseString = reader.ReadToEnd();
-                Error error = JsonConvert.DeserializeObject<Error>(responseString);
-                return new BasicApiException(response.StatusCode, error.Code, error.Message);
-            }            
+                using (Stream stream = response.GetResponseStream())
+                using (StreamReader reader = new StreamReader(stream, Encoding.UTF8))
+                {
+                    message = reader.ReadToEnd();
+                    Error error = JsonConvert.DeserializeObject<Error>(message);
+                    status = error.Code;
+                    message = error.Message;
+                }
+            }
+            catch
+            {
+            }
+            return new BasicApiException(response.StatusCode, status, message);
         }
     }
 }

--- a/OpenAPI Client/Exception/Handler/ExceptionHandler.cs
+++ b/OpenAPI Client/Exception/Handler/ExceptionHandler.cs
@@ -14,8 +14,8 @@ namespace Bol.OpenAPI.Exception.Handler
             try
             {
                 using (Stream stream = response.GetResponseStream())
-                using (StreamReader reader = new StreamReader(stream, Encoding.UTF8))
                 {
+                    StreamReader reader = new StreamReader(stream, Encoding.UTF8);
                     message = reader.ReadToEnd();
                     Error error = JsonConvert.DeserializeObject<Error>(message);
                     status = error.Code;


### PR DESCRIPTION
The exception handler parses the body of the response as json. If this fails, for example if it's a web page, then the exception handler will throw an exception.
Change it to use the body of the page as the message in this case.